### PR TITLE
Fix Sphinx config to generate links to the C++ symbols doc

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,7 +1,10 @@
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doc")
 
+file(COPY sphinx DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+configure_file(sphinx/conf.py sphinx/conf.py @ONLY)
+
 sphinx_add_docs(unfDoc
-    SOURCE "${PROJECT_SOURCE_DIR}/doc/sphinx"
+    SOURCE "${CMAKE_CURRENT_BINARY_DIR}/sphinx"
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/doc"
 )
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -13,9 +13,15 @@ if os.environ.get("READTHEDOCS"):
     import doxygen
 
     doxygen.create_cmake_config()
-    doxygen.build()
+    build_path = doxygen.build()
+    source_path = os.path.join(os.path.dirname(__file__), "..", "..")
 
     html_extra_path = ["./api"]
+
+else:
+    # variables provided by CMake if not using RTD.
+    build_path = "@CMAKE_CURRENT_BINARY_DIR@/doc"
+    source_path = "@PROJECT_SOURCE_DIR@"
 
 # The suffix of src filenames.
 source_suffix = ".rst"
@@ -27,10 +33,8 @@ master_doc = "index"
 project = u"USD Notice Framework"
 copyright = u"2023, Walt Disney Animation Studio"
 
-_root = os.path.join(os.path.dirname(__file__), "..", "..")
-
 # Version
-with open(os.path.join(_root, "CMakeLists.txt")) as _version_file:
+with open(os.path.join(source_path, "CMakeLists.txt")) as _version_file:
     _version = re.search(
         r"project\(.* VERSION ([\d\\.]+)", _version_file.read(), re.DOTALL
     ).group(1)
@@ -40,12 +44,12 @@ release = _version
 
 doxylink = {
     "usd-cpp": (
-        os.path.join(_root, "doc", "doxygen", "USD.tag"),
+        os.path.join(source_path, "doc", "doxygen", "USD.tag"),
         "https://graphics.pixar.com/usd/release/api"
     ),
     "unf-cpp": (
-        os.path.join(_root, "build", "doc", "doc", "UNF.tag"),
-        os.path.join(_root, "build", "doc", "doc", "doxygen")
+        os.path.join(build_path, "UNF.tag"),
+        "./doxygen"
     )
 }
 

--- a/doc/sphinx/doxygen.py
+++ b/doc/sphinx/doxygen.py
@@ -20,10 +20,17 @@ def build():
     output_path = os.path.join(ROOT, "api")
     os.makedirs(output_path)
 
-    return shutil.move(
+    shutil.move(
         os.path.join(build_path, "doxygen"),
         os.path.join(output_path, "doxygen")
     )
+
+    shutil.move(
+        os.path.join(build_path, "UNF.tag"),
+        os.path.join(output_path, "UNF.tag")
+    )
+
+    return output_path
 
 
 def create_cmake_config():
@@ -88,6 +95,13 @@ def fetch_api_doc_content():
     content = re.sub(
         r"(set\(\s*DOXYGEN_HTML_OUTPUT )(.*?)(\s*\))",
         r'\g<1>"doxygen"\g<3>',
+        content, re.MULTILINE | re.DOTALL
+    )
+
+    # Update tag file path.
+    content = re.sub(
+        r"(set\(\s*DOXYGEN_GENERATE_TAGFILE )(.*?)(\s*\))",
+        r'\g<1>"${CMAKE_CURRENT_BINARY_DIR}/UNF.tag"\g<3>',
         content, re.MULTILINE | re.DOTALL
     )
 

--- a/doc/sphinx/installing.rst
+++ b/doc/sphinx/installing.rst
@@ -109,7 +109,8 @@ Building documentation
 ======================
 
 Ensure that :term:`Doxygen` and :term:`Sphinx` with the `lowdown
-<https://pypi.org/project/Lowdown/>`_ extension are installed.
+<https://pypi.org/project/Lowdown/>`_ and `sphinxcontrib-doxylink
+<https://pypi.org/project/sphinxcontrib-doxylink/>`_ extensions are installed.
 
 Then build the documentation as follows::
 

--- a/doc/sphinx/release/release_notes.rst
+++ b/doc/sphinx/release/release_notes.rst
@@ -4,6 +4,14 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Fixed :term:`Sphinx` configuration to generate links to the C++ symbols
+        documentation using the `sphinxcontrib-doxylink
+        <https://pypi.org/project/sphinxcontrib-doxylink/>`_ plugin.
+
 .. release:: 0.5.0
     :date: 2023-05-10
 


### PR DESCRIPTION
Links generated by the sphinxcontrib-doxylink plugin must have a relative path to work behind a server (e.g. RTD).