### PR TITLE
Adds dependency between Sphinx and Doxygen cmake targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(BUILD_TESTS "Build tests" ON)
-option(BUILD_DOCS "Build documentation" OFF)
+option(BUILD_DOCS "Build documentation" ON)
 option(BUILD_PYTHON_BINDINGS "Build Python Bindings" ON)
 option(BUNDLE_PYTHON_TESTS "Bundle Python tests per group (faster)" OFF)
 option(BUILD_SHARED_LIBS "Build Shared Library" ON)

--- a/cmake/modules/FindSphinx.cmake
+++ b/cmake/modules/FindSphinx.cmake
@@ -52,14 +52,13 @@ if (Sphinx_FOUND AND NOT TARGET Sphinx::Build)
     )
 
     function(sphinx_add_docs targetName)
-        set(_comment "Generate documentation for ${targetName}")
-
-        cmake_parse_arguments(PARSE_ARGV 1 _args "" "SOURCE;OUTPUT" "")
+        cmake_parse_arguments(PARSE_ARGV 1 "" "" "SOURCE;OUTPUT" "DEPENDS")
 
         add_custom_target(${targetName} VERBATIM
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${_args_OUTPUT}
-            COMMAND Sphinx::Build -b html ${_args_SOURCE} ${_args_OUTPUT}
-            COMMENT ${_comment}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${_OUTPUT}
+            COMMAND Sphinx::Build -b html ${_SOURCE} ${_OUTPUT}
+            COMMENT "Generate documentation for ${targetName}"
+            DEPENDS ${_DEPENDS}
         )
     endfunction()
 endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,13 +1,5 @@
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doc")
 
-file(COPY sphinx DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-configure_file(sphinx/conf.py sphinx/conf.py @ONLY)
-
-sphinx_add_docs(unfDoc
-    SOURCE "${CMAKE_CURRENT_BINARY_DIR}/sphinx"
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/doc"
-)
-
 set(DOXYGEN_PROJECT_NAME "Usd Notice Framework")
 set(DOXYGEN_HTML_OUTPUT "doc/doxygen")
 set(DOXYGEN_EXTENSION_MAPPING "h=C++")
@@ -28,6 +20,15 @@ doxygen_add_docs(unfApiRefDoc
     "${PROJECT_SOURCE_DIR}/doc/doxygen/index.dox"
     "${PROJECT_SOURCE_DIR}/doc/doxygen/namespaces.dox"
     "${PROJECT_SOURCE_DIR}/src/unf"
+)
+
+file(COPY sphinx DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+configure_file(sphinx/conf.py sphinx/conf.py @ONLY)
+
+sphinx_add_docs(unfDoc
+    SOURCE "${CMAKE_CURRENT_BINARY_DIR}/sphinx"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/doc"
+    DEPENDS unfApiRefDoc
 )
 
 add_custom_target(documentation ALL)

--- a/doc/sphinx/installing.rst
+++ b/doc/sphinx/installing.rst
@@ -118,8 +118,8 @@ Then build the documentation as follows::
 
 .. note::
 
-    The documentation will not be automatically built by default, unless you
-    set the ``BUILD_DOCS`` :term:`CMake` option to true.
+    Documentation is automatically built with default installation, unless you
+    set the ``BUILD_DOCS`` :term:`CMake` option to false.
 
 .. _installing/test:
 

--- a/doc/sphinx/release/release_notes.rst
+++ b/doc/sphinx/release/release_notes.rst
@@ -4,6 +4,23 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Updated :term:`CMake` configuration to ensure the C++ API
+        documentation generated via :term:`Doxygen` is created before the
+        :term:`Sphinx` documentation. It was necessary as the
+        `sphinxcontrib-doxylink
+        <https://pypi.org/project/sphinxcontrib-doxylink/>`_
+        plugin depends on TAG files created by :term:`Doxygen`.
+
+    .. change:: changed
+
+        Renenabled the documentation generation by default.
+
+        .. seealso:: :ref:`installing/documentation`.
+
 .. release:: 0.5.3
     :date: 2023-05-19
 


### PR DESCRIPTION
Previously, errors would be raised when the sphinxcontrib-doxylink plugin attempted to create links while TAG files had been partially generated.

Reenabled documentation generation by default.