### PR TITLE
Update Github worflows.

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,7 +2,8 @@ name: docs-deploy
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - "*"
 
 permissions:
   contents: read

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v23.11", "v24.03"]
+        usd: ["v23.11", "v24.08"]
         python: ["3.7", "3.10"]
         include:
-          - usd: "v24.03"
+          - usd: "v24.08"
             python: "3.11"
 
     name: "USD-${{ matrix.usd }}-py${{ matrix.python }}"
@@ -75,10 +75,14 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: |
           cmake --build . --target format
-          git -C ${GITHUB_WORKSPACE} status --porcelain
-          if [ -n "$(git -C ${GITHUB_WORKSPACE} status --porcelain)" ]; \
-            then echo "Code formatting errors found."; \
-            exit 1; fi
+          STATUS_OUTPUT=$(git -C ${GITHUB_WORKSPACE} status --porcelain)
+          if [ -n "$STATUS_OUTPUT" ]; then
+            echo "Code formatting errors found:"
+            git -C ${GITHUB_WORKSPACE} diff
+            exit 1
+          else
+            echo "No formatting errors found."
+          fi
 
       - name: Run Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -15,16 +15,16 @@ permissions:
 
 jobs:
   test-windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
     timeout-minutes: 300
 
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v23.11", "v24.03"]
+        usd: ["v23.11", "v24.08"]
         python: ["3.7", "3.10"]
         include:
-          - usd: "v24.03"
+          - usd: "v24.08"
             python: "3.11"
 
     name: "USD-${{ matrix.usd }}-py${{ matrix.python }}"
@@ -54,7 +54,7 @@ jobs:
           git clone https://github.com/PixarAnimationStudios/OpenUSD.git ^
               --depth 1 --branch ${{ matrix.usd }} ./src
           python ./src/build_scripts/build_usd.py . ^
-              --generator "Visual Studio 17 2022" ^
+              --generator "Visual Studio 16 2019" ^
               --no-tests ^
               --no-examples ^
               --no-tutorials ^
@@ -71,7 +71,7 @@ jobs:
           export PATH="${{runner.temp}}/USD/bin;${{runner.temp}}/USD/lib;${PATH}"
           export PYTHONPATH="${{runner.temp}}/USD/lib/python;${PYTHONPATH}"
           cmake \
-            -G "Visual Studio 17 2022" -A x64 \
+            -G "Visual Studio 16 2019" -A x64 \
             -D "CMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" \
             -D "VCPKG_TARGET_TRIPLET=x64-windows" \
             -D "BUILD_DOCS=OFF" \
@@ -85,10 +85,14 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: |
           cmake --build . --target format
-          git -C ${GITHUB_WORKSPACE} status --porcelain
-          if [ -n "$(git -C ${GITHUB_WORKSPACE} status --porcelain)" ]; \
-            then echo "Code formatting errors found."; \
-            exit 1; fi
+          STATUS_OUTPUT=$(git -C ${GITHUB_WORKSPACE} status --porcelain)
+          if [ -n "$STATUS_OUTPUT" ]; then
+            echo "Code formatting errors found:"
+            git -C ${GITHUB_WORKSPACE} diff
+            exit 1
+          else
+            echo "No formatting errors found."
+          fi
 
       - name: Run Test
         shell: bash

--- a/doc/sphinx/release/release_notes.rst
+++ b/doc/sphinx/release/release_notes.rst
@@ -4,6 +4,17 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+
+        Updated Github workflow configuration to test library against
+        :term:`USD` v24.08.
+
+    .. change:: fixed
+
+        Fixed Windows CI test errors by reverting to 'windows-2019' image.
+
 .. release:: 0.6.3
     :date: 2024-07-23
 

--- a/src/unf/notice.h
+++ b/src/unf/notice.h
@@ -74,7 +74,7 @@ class StageNotice : public PXR_NS::TfNotice, public PXR_NS::TfRefBase {
     /// transaction.
     ///
     /// By default, no process is done.
-    virtual void PostProcess(){};
+    virtual void PostProcess() {}
 
     /// \brief
     /// Interface method for returing unique type identifier.


### PR DESCRIPTION
- Fix Windows CI errors to use the 'windows-2019' image instead of 'windows-2022' to address DLL initialization errors when loading the 'unf' Python module. The errors are likely caused by the OpenUSD build script, which includes a Boost version incompatible with MSVC 14.40 in the updated 'windows-2022' image.
- Update Github CI script to only deploy documentation when a tag is pushed;
- Update Github CI script to display formatting error when necessary;
- Update tests to use latest OpenUSD v24.08;
- Fix formatting issues;