### PR TITLE
Improve USD and Boost.Python compatibility across versions

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -2,7 +2,7 @@ name: test-linux
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
 
@@ -15,17 +15,14 @@ permissions:
 
 jobs:
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 300
 
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v23.11", "v24.08"]
-        python: ["3.7", "3.10"]
-        include:
-          - usd: "v24.08"
-            python: "3.11"
+        usd: ["v25.05"]
+        python: ["3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}-py${{ matrix.python }}"
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -2,7 +2,7 @@ name: test-windows
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
 
@@ -21,11 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v23.11", "v24.08"]
-        python: ["3.7", "3.10"]
-        include:
-          - usd: "v24.08"
-            python: "3.11"
+        usd: ["v25.05"]
+        python: ["3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}-py${{ matrix.python }}"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 # https://cmake.org/cmake/help/latest/policy/CMP0094.html
 cmake_policy(SET CMP0094 NEW)
 
+find_package(USD 0.20.11 REQUIRED)
+find_package(TBB 2017.0 COMPONENTS tbb REQUIRED)
+
 if(BUILD_PYTHON_BINDINGS)
     # The 'manylinux' images do not include the Python library.
     # CMake >= 3.18 is required for this option to work as expected.
@@ -82,11 +85,13 @@ if(BUILD_PYTHON_BINDINGS)
     set(_py_version ${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
     mark_as_advanced(_py_version)
 
-    find_package(Boost 1.70.0 COMPONENTS "python${_py_version}" REQUIRED)
+    if (NOT USD_USE_INTERNAL_BOOST_PYTHON)
+        find_package(Boost 1.70.0 COMPONENTS "python${_py_version}" REQUIRED)
 
-    # Define generic target for Boost Python if necessary.
-    if (NOT TARGET Boost::python)
-        add_library(Boost::python ALIAS "Boost::python${_py_version}")
+        # Define generic target for Boost Python if necessary.
+        if (NOT TARGET Boost::python)
+            add_library(Boost::python ALIAS "Boost::python${_py_version}")
+        endif()
     endif()
 
     # Set variable to identify the path to install and test python libraries.
@@ -97,12 +102,7 @@ if(BUILD_PYTHON_BINDINGS)
     set(PYTHON_DESTINATION
         "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION}/site-packages"
         CACHE INTERNAL "Python library path.")
-else()
-    find_package(Boost 1.70.0 REQUIRED)
 endif()
-
-find_package(USD 0.20.11 REQUIRED)
-find_package(TBB 2017.0 COMPONENTS tbb REQUIRED)
 
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,12 @@ target_link_libraries(unf
         usd::vt
 )
 
+# Transitive Pixar libraries depend on vendorized Boost.Python
+# (Required due to manual CMake module used to locate USD)
+if (BUILD_PYTHON_BINDINGS)
+    target_link_libraries(unf PUBLIC usd::boost usd::python)
+endif()
+
 install(
     TARGETS unf
     EXPORT ${PROJECT_NAME}

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -29,11 +29,13 @@ target_include_directories(pyUnf
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_libraries(pyUnf
-    PUBLIC
-        unf
-        Boost::python
-)
+target_link_libraries(pyUnf PUBLIC unf)
+
+if (NOT USD_USE_INTERNAL_BOOST_PYTHON)
+    target_link_libraries(pyUnf PUBLIC Boost::python)
+else()
+    target_link_libraries(pyUnf PUBLIC usd::boost usd::python)
+endif()
 
 set_target_properties(pyUnf
     PROPERTIES

--- a/src/python/predicate.h
+++ b/src/python/predicate.h
@@ -8,11 +8,16 @@
 #include <pxr/base/tf/pyNoticeWrapper.h>
 #include <pxr/pxr.h>
 
+#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
 #include <boost/python.hpp>
+using namespace boost::python;
+#else
+#include <pxr/external/boost/python.hpp>
+using namespace PXR_BOOST_PYTHON_NAMESPACE;
+#endif
 
 #include <functional>
 
-using namespace boost::python;
 using namespace unf;
 
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/src/python/wrapBroker.cpp
+++ b/src/python/wrapBroker.cpp
@@ -13,9 +13,16 @@
 #include <pxr/usd/usd/common.h>
 #include <pxr/usd/usd/stage.h>
 
+#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
 #include <boost/python.hpp>
-
 using namespace boost::python;
+using noncopyable = boost::noncopyable;
+#else
+#include <pxr/external/boost/python.hpp>
+using namespace PXR_BOOST_PYTHON_NAMESPACE;
+using noncopyable = PXR_BOOST_PYTHON_NAMESPACE::noncopyable;
+#endif
+
 using namespace unf;
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -31,7 +38,7 @@ void wrapBroker()
     // Ensure that predicate function can be passed from Python.
     TfPyFunctionFromPython<_CapturePredicateFuncRaw>();
 
-    class_<Broker, BrokerWeakPtr, boost::noncopyable>(
+    class_<Broker, BrokerWeakPtr, noncopyable>(
         "Broker",
         "Intermediate object between the Usd Stage and any clients that needs "
         "asynchronous handling and upstream filtering of notices.",

--- a/src/python/wrapCapturePredicate.cpp
+++ b/src/python/wrapCapturePredicate.cpp
@@ -2,9 +2,14 @@
 
 #include "unf/capturePredicate.h"
 
+#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
 #include <boost/python.hpp>
-
 using namespace boost::python;
+#else
+#include <pxr/external/boost/python.hpp>
+using namespace PXR_BOOST_PYTHON_NAMESPACE;
+#endif
+
 using namespace unf;
 
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/src/python/wrapNotice.cpp
+++ b/src/python/wrapNotice.cpp
@@ -9,9 +9,14 @@
 
 #include <pxr/pxr.h>
 
+#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
 #include <boost/python.hpp>
-
 using namespace boost::python;
+#else
+#include <pxr/external/boost/python.hpp>
+using namespace PXR_BOOST_PYTHON_NAMESPACE;
+#endif
+
 using namespace unf::UnfNotice;
 
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/src/python/wrapTransaction.cpp
+++ b/src/python/wrapTransaction.cpp
@@ -9,10 +9,16 @@
 #include <pxr/usd/usd/common.h>
 #include <pxr/usd/usd/stage.h>
 
+#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
 #include <boost/python.hpp>
 #include <boost/python/return_internal_reference.hpp>
-
 using namespace boost::python;
+#else
+#include <pxr/external/boost/python.hpp>
+#include <pxr/external/boost/python/return_internal_reference.hpp>
+using namespace PXR_BOOST_PYTHON_NAMESPACE;
+#endif
+
 using namespace unf;
 
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/test/utility/unfTest/observer.h
+++ b/test/utility/unfTest/observer.h
@@ -6,8 +6,7 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/stage.h>
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <exception>
 
 namespace Test {
@@ -64,7 +63,7 @@ class Observer : public PXR_NS::TfWeakBase {
         }
     }
 
-    boost::optional<T> _notice;
+    std::optional<T> _notice;
     size_t _count;
     PXR_NS::TfNotice::Key _key;
     std::function<void(const T&)> _callback;


### PR DESCRIPTION
- Update GitHub workflows to test against newer OpenUSD and Python versions;
- Adjust FindUSD.cmake to detect and respect internal Boost.Python usage,
  avoiding external Boost::python if not needed by inspecting 'pxr.h';
- Update Python bindings to use appropriate Boost.Python namespace (internal or external);
- Replace deprecated `boost::optional` with `std::optional` in test utilities.