### PR TITLE
Fix USD detection for v24.08 compatibility

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v25.05"]
+        usd: ["v24.08", "v25.05"]
         python: ["3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}-py${{ matrix.python }}"
@@ -42,11 +42,23 @@ jobs:
           mkdir -p ${{github.workspace}}/build
           mkdir -p ${{runner.temp}}/USD
 
-      - name: Install USD
+      - name: Download USD
         working-directory: ${{runner.temp}}/USD
         run: |
           git clone https://github.com/PixarAnimationStudios/OpenUSD.git \
               --depth 1 --branch ${{ matrix.usd }} ./src
+
+      - name: Apply patch for USD v24.08
+        if: matrix.usd == 'v24.08'
+        working-directory: ${{runner.temp}}/USD
+        run: |
+          sed -i '/BOOST_URL/ s|boostorg.jfrog.io.*/release|sourceforge.net/projects/boost/files/boost|' src/build_scripts/build_usd.py
+          sed -i '/BOOST_URL/ s|source/boost|boost|' src/build_scripts/build_usd.py
+          sed -i '/BOOST_URL/ s|\.zip"|.zip/download"|' src/build_scripts/build_usd.py
+
+      - name: Install USD
+        working-directory: ${{runner.temp}}/USD
+        run: |
           python ./src/build_scripts/build_usd.py . \
               --no-tests \
               --no-examples \

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v25.05"]
+        usd: ["v24.08", "v25.05"]
         python: ["3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}-py${{ matrix.python }}"
@@ -41,6 +41,22 @@ jobs:
           cmake -E make_directory ${{github.workspace}}\build
           cmake -E make_directory ${{runner.temp}}\USD
 
+      - name: Download USD
+        working-directory: ${{runner.temp}}/USD
+        shell: cmd
+        run: |
+          git clone https://github.com/PixarAnimationStudios/OpenUSD.git ^
+              --depth 1 --branch ${{ matrix.usd }} ./src
+
+      - name: Apply patch for USD v24.08
+        if: matrix.usd == 'v24.08'
+        working-directory: ${{runner.temp}}/USD
+        shell: bash
+        run: |
+          sed -i '/BOOST_URL/ s|boostorg.jfrog.io.*/release|sourceforge.net/projects/boost/files/boost|' src/build_scripts/build_usd.py
+          sed -i '/BOOST_URL/ s|source/boost|boost|' src/build_scripts/build_usd.py
+          sed -i '/BOOST_URL/ s|\.zip"|.zip/download"|' src/build_scripts/build_usd.py
+
       - name: Install USD
         working-directory: ${{runner.temp}}/USD
         shell: cmd
@@ -48,8 +64,6 @@ jobs:
           call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
           set VCPKG_TARGET_TRIPLET=x64-windows
           set CMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake
-          git clone https://github.com/PixarAnimationStudios/OpenUSD.git ^
-              --depth 1 --branch ${{ matrix.usd }} ./src
           python ./src/build_scripts/build_usd.py . ^
               --generator "Visual Studio 16 2019" ^
               --no-tests ^

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -111,8 +111,6 @@ find_package_handle_standard_args(
         plug_LIBRARY
         arch_LIBRARY
         vt_LIBRARY
-        boost_LIBRARY
-        python_LIBRARY
     VERSION_VAR
         USD_VERSION
 )

--- a/doc/sphinx/release/release_notes.rst
+++ b/doc/sphinx/release/release_notes.rst
@@ -4,6 +4,13 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Fixed CMake module to detect USD without requiring `usd::boost` or `usd::python`,
+        maintaining compatibility with OpenUSD v24.08.
+
 .. release:: 0.8.1
     :date: 2025-05-13
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(unf
 
 # Transitive Pixar libraries depend on vendorized Boost.Python
 # (Required due to manual CMake module used to locate USD)
-if (BUILD_PYTHON_BINDINGS)
+if (BUILD_PYTHON_BINDINGS AND USD_USE_INTERNAL_BOOST_PYTHON)
     target_link_libraries(unf PUBLIC usd::boost usd::python)
 endif()
 


### PR DESCRIPTION
Fix CMake module to detect USD without requiring `usd::boost` or `usd::python`, maintaining compatibility with OpenUSD v24.08.