### PR TITLE
python: remove support for Boost::python

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v24.08", "v25.05"]
+        usd: ["v25.05"]
         python: ["", "3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}${{ matrix.python != '' && format('-py{0}', matrix.python) || '-no-py' }}"
@@ -52,14 +52,6 @@ jobs:
         run: |
           git clone https://github.com/PixarAnimationStudios/OpenUSD.git \
               --depth 1 --branch ${{ matrix.usd }} ./src
-
-      - name: Apply patch for USD v24.08
-        if: matrix.usd == 'v24.08'
-        working-directory: ${{runner.temp}}/USD
-        run: |
-          sed -i '/BOOST_URL/ s|boostorg.jfrog.io.*/release|sourceforge.net/projects/boost/files/boost|' src/build_scripts/build_usd.py
-          sed -i '/BOOST_URL/ s|source/boost|boost|' src/build_scripts/build_usd.py
-          sed -i '/BOOST_URL/ s|\.zip"|.zip/download"|' src/build_scripts/build_usd.py
 
       - name: Install USD
         if: matrix.python != ''

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v25.05"]
+        usd: ["v25.11", "v26.03"]
         python: ["", "3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}${{ matrix.python != '' && format('-py{0}', matrix.python) || '-no-py' }}"
@@ -124,4 +124,4 @@ jobs:
         run: ctest -VV
         env:
           CTEST_OUTPUT_ON_FAILURE: True
-
+          PCP_ENABLE_MINIMAL_CHANGES_FOR_LAYER_OPERATIONS: 0

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v25.05.01"]
+        usd: ["v25.11", "v26.03"]
         python: ["", "3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}${{ matrix.python != '' && format('-py{0}', matrix.python) || '-no-py' }}"
@@ -146,3 +146,4 @@ jobs:
         run: ctest -VV -C Release
         env:
           CTEST_OUTPUT_ON_FAILURE: True
+          PCP_ENABLE_MINIMAL_CHANGES_FOR_LAYER_OPERATIONS: 0

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        usd: ["v24.08", "v25.05.01"]
+        usd: ["v25.05.01"]
         python: ["", "3.10", "3.12"]
 
     name: "USD-${{ matrix.usd }}${{ matrix.python != '' && format('-py{0}', matrix.python) || '-no-py' }}"
@@ -52,15 +52,6 @@ jobs:
         run: |
           git clone https://github.com/PixarAnimationStudios/OpenUSD.git ^
               --depth 1 --branch ${{ matrix.usd }} ./src
-
-      - name: Apply patch for USD v24.08
-        if: matrix.usd == 'v24.08'
-        working-directory: ${{runner.temp}}/USD
-        shell: bash
-        run: |
-          sed -i '/BOOST_URL/ s|boostorg.jfrog.io.*/release|sourceforge.net/projects/boost/files/boost|' src/build_scripts/build_usd.py
-          sed -i '/BOOST_URL/ s|source/boost|boost|' src/build_scripts/build_usd.py
-          sed -i '/BOOST_URL/ s|\.zip"|.zip/download"|' src/build_scripts/build_usd.py
 
       - name: Install USD
         if: matrix.python != ''

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,15 +86,6 @@ if(BUILD_PYTHON_BINDINGS)
     set(_py_version ${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
     mark_as_advanced(_py_version)
 
-    if (NOT USD_USE_INTERNAL_BOOST_PYTHON)
-        find_package(Boost 1.70.0 COMPONENTS "python${_py_version}" REQUIRED)
-
-        # Define generic target for Boost Python if necessary.
-        if (NOT TARGET Boost::python)
-            add_library(Boost::python ALIAS "Boost::python${_py_version}")
-        endif()
-    endif()
-
     # Set variable to identify the path to install and test python libraries.
     set(PYTHON_VERSION
         "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -75,26 +75,10 @@ if(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
         list(APPEND USD_DEPENDENCIES "Python::Python")
     endif()
 
-    # Detect whether PXR_USE_INTERNAL_BOOST_PYTHON is explicitly enabled
-    set(USD_USE_INTERNAL_BOOST_PYTHON ON CACHE INTERNAL "")
-    string(REGEX MATCH
-        "#if +0[^\n]*\n[ \t]*#define +PXR_USE_INTERNAL_BOOST_PYTHON"
-        _use_external_boost_python "${_pxr_header}")
-
-    # Use external Boost dependencies if USD version is less than 0.25.5, and
-    # if internal Boost.Python is not explicitly disabled
-    if (USD_VERSION VERSION_LESS "0.25.5" OR _use_external_boost_python)
-        set(USD_USE_INTERNAL_BOOST_PYTHON OFF CACHE INTERNAL "")
-        if (BUILD_PYTHON_BINDINGS)
-            list(APPEND USD_DEPENDENCIES "Boost::boost" "Boost::python")
-        endif()
-    endif()
-
     mark_as_advanced(
         _pxr_MAJOR
         _pxr_MINOR
         _pxr_PATCH
-        _use_external_boost_python
         USD_VERSION
         USD_DEPENDENCIES
     )

--- a/doc/sphinx/release/release_notes.rst
+++ b/doc/sphinx/release/release_notes.rst
@@ -4,6 +4,13 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+
+        USD versions older than 25.11 are no longer supported.
+
+
 .. release:: 0.9.0
     :date: 2025-10-04
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(unf
 
 # Transitive Pixar libraries depend on vendorized Boost.Python
 # (Required due to manual CMake module used to locate USD)
-if (BUILD_PYTHON_BINDINGS AND USD_USE_INTERNAL_BOOST_PYTHON)
+if (BUILD_PYTHON_BINDINGS)
     target_link_libraries(unf PUBLIC usd::boost usd::python)
 endif()
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -29,13 +29,7 @@ target_include_directories(pyUnf
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_libraries(pyUnf PUBLIC unf)
-
-if (NOT USD_USE_INTERNAL_BOOST_PYTHON)
-    target_link_libraries(pyUnf PUBLIC Boost::python)
-else()
-    target_link_libraries(pyUnf PUBLIC usd::boost usd::python)
-endif()
+target_link_libraries(pyUnf PUBLIC unf usd::boost usd::python)
 
 set_target_properties(pyUnf
     PROPERTIES

--- a/src/python/predicate.h
+++ b/src/python/predicate.h
@@ -8,13 +8,8 @@
 #include <pxr/base/tf/pyNoticeWrapper.h>
 #include <pxr/pxr.h>
 
-#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
-#include <boost/python.hpp>
-using namespace boost::python;
-#else
 #include <pxr/external/boost/python.hpp>
 using namespace PXR_BOOST_PYTHON_NAMESPACE;
-#endif
 
 #include <functional>
 

--- a/src/python/wrapBroker.cpp
+++ b/src/python/wrapBroker.cpp
@@ -13,15 +13,9 @@
 #include <pxr/usd/usd/common.h>
 #include <pxr/usd/usd/stage.h>
 
-#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
-#include <boost/python.hpp>
-using namespace boost::python;
-using noncopyable = boost::noncopyable;
-#else
 #include <pxr/external/boost/python.hpp>
 using namespace PXR_BOOST_PYTHON_NAMESPACE;
 using noncopyable = PXR_BOOST_PYTHON_NAMESPACE::noncopyable;
-#endif
 
 using namespace unf;
 

--- a/src/python/wrapCapturePredicate.cpp
+++ b/src/python/wrapCapturePredicate.cpp
@@ -4,13 +4,8 @@
 
 #include "unf/capturePredicate.h"
 
-#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
-#include <boost/python.hpp>
-using namespace boost::python;
-#else
 #include <pxr/external/boost/python.hpp>
 using namespace PXR_BOOST_PYTHON_NAMESPACE;
-#endif
 
 using namespace unf;
 

--- a/src/python/wrapNotice.cpp
+++ b/src/python/wrapNotice.cpp
@@ -9,13 +9,8 @@
 
 #include <pxr/pxr.h>
 
-#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
-#include <boost/python.hpp>
-using namespace boost::python;
-#else
 #include <pxr/external/boost/python.hpp>
 using namespace PXR_BOOST_PYTHON_NAMESPACE;
-#endif
 
 using namespace unf::UnfNotice;
 

--- a/src/python/wrapTransaction.cpp
+++ b/src/python/wrapTransaction.cpp
@@ -11,15 +11,9 @@
 #include <pxr/usd/usd/common.h>
 #include <pxr/usd/usd/stage.h>
 
-#ifndef PXR_USE_INTERNAL_BOOST_PYTHON
-#include <boost/python.hpp>
-#include <boost/python/return_internal_reference.hpp>
-using namespace boost::python;
-#else
 #include <pxr/external/boost/python.hpp>
 #include <pxr/external/boost/python/return_internal_reference.hpp>
 using namespace PXR_BOOST_PYTHON_NAMESPACE;
-#endif
 
 using namespace unf;
 


### PR DESCRIPTION
We no longer support USD < 25.11. Remove dead code.

Resolves: PUP-3206