### PR TITLE
github actions updates for Node 24 and TBB

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -91,6 +91,7 @@ jobs:
               -D "BUILD_DOCS=OFF" \
               -D "CMAKE_INCLUDE_PATH=${{runner.temp}}/USD/include" \
               -D "CMAKE_LIBRARY_PATH=${{runner.temp}}/USD/lib" \
+              -D "TBB_VERSION_H=${{runner.temp}}/USD/include/tbb/tbb_stddef.h" \
               ..
           cmake --build . --config Release
 
@@ -103,6 +104,7 @@ jobs:
               -D "BUILD_PYTHON_BINDINGS=OFF" \
               -D "CMAKE_INCLUDE_PATH=${{runner.temp}}/USD/include" \
               -D "CMAKE_LIBRARY_PATH=${{runner.temp}}/USD/lib" \
+              -D "TBB_VERSION_H=${{runner.temp}}/USD/include/tbb/tbb_stddef.h" \
               ..
           cmake --build . --config Release
 

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -27,7 +27,7 @@ jobs:
     name: "USD-${{ matrix.usd }}${{ matrix.python != '' && format('-py{0}', matrix.python) || '-no-py' }}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python }}
         if: matrix.python != ''

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -106,6 +106,7 @@ jobs:
             -D "BUILD_DOCS=OFF" \
             -D "CMAKE_INCLUDE_PATH=${{runner.temp}}/USD/include" \
             -D "CMAKE_LIBRARY_PATH=${{runner.temp}}/USD/lib" \
+            -D "TBB_VERSION_H=${{runner.temp}}/USD/include/tbb/tbb_stddef.h" \
             ..
           cmake --build . --config Release
 
@@ -123,6 +124,7 @@ jobs:
             -D "BUILD_PYTHON_BINDINGS=OFF" \
             -D "CMAKE_INCLUDE_PATH=${{runner.temp}}/USD/include" \
             -D "CMAKE_LIBRARY_PATH=${{runner.temp}}/USD/lib" \
+            -D "TBB_VERSION_H=${{runner.temp}}/USD/include/tbb/tbb_stddef.h" \
             ..
           cmake --build . --config Release
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -27,7 +27,7 @@ jobs:
     name: "USD-${{ matrix.usd }}${{ matrix.python != '' && format('-py{0}', matrix.python) || '-no-py' }}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python }}
         if: matrix.python != ''


### PR DESCRIPTION
Recent changes were made that caused the CI tests to start failing.

Update the github actions to account for the change in behavior. 

Upgrade actions/checkout to v5 to eliminate deprecation warnings.